### PR TITLE
Fix ScriptFunctionPointer

### DIFF
--- a/apps/openmw-mp/Script/Types.hpp
+++ b/apps/openmw-mp/Script/Types.hpp
@@ -99,13 +99,9 @@ struct CallbackIdentity
 struct ScriptFunctionPointer : public ScriptIdentity
 {
     void *addr;
-#if (!defined(__clang__) && defined(__GNUC__))
+
     template<typename R, typename... Types>
-    constexpr ScriptFunctionPointer(Function<R, Types...> addr) : ScriptIdentity(addr), addr((void*)(addr)) {}
-#else
-    template<typename R, typename... Types>
-    constexpr ScriptFunctionPointer(Function<R, Types...> addr) : ScriptIdentity(addr), addr(addr) {}
-#endif
+    constexpr ScriptFunctionPointer(Function<R, Types...> addr) : ScriptIdentity(addr), addr(reinterpret_cast<void*>(reinterpret_cast<intptr_t>(addr))) {}
 };
 
 struct ScriptFunctionData


### PR DESCRIPTION
This fixes ScriptFunctionPointer previously preventing the build. From what I can tell we shouldn't need the if check anymore due to newer versions of GCC supporting arm natively. 
But haven't tested arm and we may need to handle that in the future.